### PR TITLE
Fix RESX incorrect command path order

### DIFF
--- a/Discord.Net.Tools.Localization.Resx/Program.cs
+++ b/Discord.Net.Tools.Localization.Resx/Program.cs
@@ -49,7 +49,7 @@ void WriteRestCommandOption(RestApplicationCommandOption option, ResXResourceWri
     if(!(string.IsNullOrEmpty(option.Description) && o.SkipNullOrEmpty))
         rw.AddResource(CreateDescriptionKey(option.Name, path), option.Description);
 
-    var optionPath = PathCombine(path, option.Name);
+    var optionPath = PathCombine(option.Name, path);
 
     if (option.Options.Count != 0)
         foreach (var subOption in option.Options)


### PR DESCRIPTION
When parsing a command that is in a sub-command group; the group and sub-command group names are swapped around.

Currently outputs
`group2.group1.command.name`

Should be
`group1.group2.command.name`

I swapped the parameters around to fix and keep consistent with the rest of the code.